### PR TITLE
Add nonzero-mean GP implementation

### DIFF
--- a/examples/logp_regression.py
+++ b/examples/logp_regression.py
@@ -39,7 +39,7 @@ def main(rng: random.Random, fp_size: int, N_train: int, N_test: int):
             mol
         )  # replace with "GetCountFingerprint" for fingerprint of size fpSize
 
-    gp = tanimoto_gp.TanimotoGP(smiles_to_fp, smiles_train, y_train)
+    gp = tanimoto_gp.ZeroMeanTanimotoGP(smiles_to_fp, smiles_train, y_train)
     gp_params = tanimoto_gp.TanimotoGP_Params(raw_amplitude=jnp.asarray(1.0), raw_noise=jnp.asarray(1e-2))
 
     print(f"Start MLL: {gp.marginal_log_likelihood(params=gp_params)}")

--- a/examples/logp_regression.py
+++ b/examples/logp_regression.py
@@ -39,7 +39,7 @@ def main(rng: random.Random, fp_size: int, N_train: int, N_test: int):
             mol
         )  # replace with "GetCountFingerprint" for fingerprint of size fpSize
 
-    gp = tanimoto_gp.ZeroMeanTanimotoGP(smiles_to_fp, smiles_train, y_train)
+    gp = tanimoto_gp.TanimotoGP(smiles_to_fp, smiles_train, y_train)
     gp_params = tanimoto_gp.TanimotoGP_Params(raw_amplitude=jnp.asarray(1.0), raw_noise=jnp.asarray(1e-2))
 
     print(f"Start MLL: {gp.marginal_log_likelihood(params=gp_params)}")

--- a/tanimoto_gp/__init__.py
+++ b/tanimoto_gp/__init__.py
@@ -14,15 +14,14 @@ class TanimotoGP_Params(NamedTuple):
     raw_noise: jnp.ndarray
 
 
-class ZeroMeanTanimotoGP:
-    def __init__(self, fp_func: Callable[[str], Any], smiles_train: list[str], y_train):
-        super().__init__()
+class BaseTanimotoGP:
+    """Base class for Tanimoto kernel Gaussian Process implementation."""
+
+    def __init__(self, fp_func: Callable[[str], Any], smiles_train: list[str], y_train) -> None:
         self._fp_func = fp_func
         self.set_training_data(smiles_train, y_train)
 
-    def set_training_data(self, smiles_train: list[str], y_train: jnp.ndarray):
-        self._smiles_train = smiles_train
-        self._y_train = jnp.asarray(y_train)
+    def _setup_kernel(self, smiles_train: list[str]) -> None:
         self._fp_train = [self._fp_func(smiles) for smiles in smiles_train]
         self._K_train_train = jnp.asarray(
             [DataStructs.BulkTanimotoSimilarity(fp, self._fp_train) for fp in self._fp_train]
@@ -33,18 +32,17 @@ class ZeroMeanTanimotoGP:
             a=TRANSFORM(params.raw_amplitude),
             s=TRANSFORM(params.raw_noise),
             k_train_train=self._K_train_train,
-            y_train=self._y_train,
+            y_train=self._get_training_targets(),
         )
 
     def predict_f(self, params: TanimotoGP_Params, smiles_test: list[str], full_covar: bool = True) -> jnp.ndarray:
-
-        # Construct kernel matrices
         fp_test = [self._fp_func(smiles) for smiles in smiles_test]
         K_test_train = jnp.asarray([DataStructs.BulkTanimotoSimilarity(fp, self._fp_train) for fp in fp_test])
-        if full_covar:
-            K_test_test = jnp.asarray([DataStructs.BulkTanimotoSimilarity(fp, fp_test) for fp in fp_test])
-        else:
-            K_test_test = jnp.ones((len(smiles_test)), dtype=float)
+        K_test_test = (
+            jnp.asarray([DataStructs.BulkTanimotoSimilarity(fp, fp_test) for fp in fp_test])
+            if full_covar
+            else jnp.ones((len(smiles_test)), dtype=float)
+        )
 
         return kgp.noiseless_predict(
             a=TRANSFORM(params.raw_amplitude),
@@ -52,9 +50,28 @@ class ZeroMeanTanimotoGP:
             k_train_train=self._K_train_train,
             k_test_train=K_test_train,
             k_test_test=K_test_test,
-            y_train=self._y_train,
+            y_train=self._get_training_targets(),
             full_covar=full_covar,
         )
+
+    def _get_training_targets(self) -> jnp.ndarray:
+        raise NotImplementedError
+
+    def predict_y(self, params: TanimotoGP_Params, smiles_test: list[str], full_covar: bool = True) -> jnp.ndarray:
+        raise NotImplementedError
+
+
+class ZeroMeanTanimotoGP(BaseTanimotoGP):
+    """Tanimoto GP implementation with zero mean function."""
+
+    def set_training_data(self, smiles_train: list[str], y_train: jnp.ndarray) -> None:
+        self._smiles_train = smiles_train
+        self._y_train = jnp.asarray(y_train)
+        self._setup_kernel(smiles_train)
+
+    def _get_training_targets(self) -> jnp.ndarray:
+        """Get uncentered training targets"""
+        return self._y_train
 
     def predict_y(self, params: TanimotoGP_Params, smiles_test: list[str], full_covar: bool = True) -> jnp.ndarray:
         mean, covar = self.predict_f(params, smiles_test, full_covar)
@@ -63,3 +80,28 @@ class ZeroMeanTanimotoGP:
         else:
             covar += TRANSFORM(params.raw_noise)
         return mean, covar
+
+
+class TanimotoGP(BaseTanimotoGP):
+    """Tanimoto GP implementation with mean function set to training data mean."""
+
+    def set_training_data(self, smiles_train, y_train) -> None:
+        self._smiles_train = smiles_train
+        self._y_train = jnp.asarray(y_train)
+        self._y_mean = jnp.mean(self._y_train)  # Compute mean of training data
+        self._y_centered = self._y_train - self._y_mean  # Center training data by subtracting mean
+        self._setup_kernel(smiles_train)
+
+    def _get_training_targets(self) -> jnp.ndarray:
+        """Get uncentered training targets"""
+        return self._y_centered
+
+    def predict_y(self, params: TanimotoGP_Params, smiles_test: list[str], full_covar: bool = True) -> jnp.ndarray:
+        """Predict observed values for test points with added mean."""
+
+        mean, covar = self.predict_f(params, smiles_test, full_covar)
+        if full_covar:
+            covar = covar + jnp.eye(len(smiles_test)) * TRANSFORM(params.raw_noise)
+        else:
+            covar += TRANSFORM(params.raw_noise)
+        return mean + self._y_mean, covar

--- a/tanimoto_gp/__init__.py
+++ b/tanimoto_gp/__init__.py
@@ -92,7 +92,7 @@ class TanimotoGP(BaseTanimotoGP):
         self._setup_kernel(smiles_train)
 
     def _get_training_targets(self) -> jnp.ndarray:
-        """Get uncentered training targets"""
+        """Get centered training targets"""
         return self._y_centered
 
     def predict_y(self, params: TanimotoGP_Params, smiles_test: list[str], full_covar: bool = True) -> jnp.ndarray:

--- a/tanimoto_gp/__init__.py
+++ b/tanimoto_gp/__init__.py
@@ -38,11 +38,10 @@ class BaseTanimotoGP:
     def predict_f(self, params: TanimotoGP_Params, smiles_test: list[str], full_covar: bool = True) -> jnp.ndarray:
         fp_test = [self._fp_func(smiles) for smiles in smiles_test]
         K_test_train = jnp.asarray([DataStructs.BulkTanimotoSimilarity(fp, self._fp_train) for fp in fp_test])
-        K_test_test = (
-            jnp.asarray([DataStructs.BulkTanimotoSimilarity(fp, fp_test) for fp in fp_test])
-            if full_covar
-            else jnp.ones((len(smiles_test)), dtype=float)
-        )
+        if full_covar:
+            K_test_test = jnp.asarray([DataStructs.BulkTanimotoSimilarity(fp, fp_test) for fp in fp_test])
+        else:
+            K_test_test = jnp.ones((len(smiles_test)), dtype=float)
 
         return kgp.noiseless_predict(
             a=TRANSFORM(params.raw_amplitude),


### PR DESCRIPTION
This PR refactors the `tanimoto_gp` module to support both zero-mean and nonzero-mean GPs.

### Summary of Changes:
* Created base class `BaseTanimotoGP` that contains shared functionality between GP models
* Split GP implementations into two classes:
   * ZeroMeanTanimotoGP: Original implementation with zero mean (behavior unchanged)
   * TanimotoGP: New implementation that uses training data mean as constant mean function

```py
# Old usage (unchanged)
gp = ZeroMeanTanimotoGP(smiles_to_fp, smiles_train, y_train)

# New alternative with nonzero mean
gp = TanimotoGP(smiles_to_fp, smiles_train, y_train)
```

Tested model on `logp_regression.py` script